### PR TITLE
Added file to manage package version

### DIFF
--- a/Eng/Dependencies.props
+++ b/Eng/Dependencies.props
@@ -1,0 +1,8 @@
+<Project>
+    <ItemGroup>
+        <NewtonsoftJsonPackageVersion>11.0.1</NewtonsoftJsonPackageVersion>
+        <MicrosoftAspNetCoreSignalRClientPackageVersion>5.0.5</MicrosoftAspNetCoreSignalRClientPackageVersion> 
+        <MicrosoftAzureSignalRPackageVersion>1.8.0</MicrosoftAzureSignalRPackageVersion>
+        <MicrosoftAspNetCoreStaticFilesPackageVersion>2.2.0</MicrosoftAspNetCoreStaticFilesPackageVersion>
+    </ItemGroup>
+</Project>

--- a/WebClient/WebClient.csproj
+++ b/WebClient/WebClient.csproj
@@ -4,4 +4,10 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\js\" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
- For now only used the new package version notation to manage MicrosoftAspNetCoreStaticFiles 
- When upstream master gets updated with the new WPFClient and WebClient .csproj files with additional packages, we need to modify those files accordingly